### PR TITLE
Update HELICS GitHub repo url

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,7 +1,7 @@
 # Support resources
 
 ## For HELICS and HELICS-FMI
-We have an active [Gitter]((https://gitter.im/GMLC-TDC/HELICS-src) channel
-Our GitHub pages provides a rich set of [documentation](https://helics.readthedocs.io/en/latest/) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen-auto-produced [API documentation](https://helics.readthedocs.io/en/latest/doxygen/index.html), There is a [WIKI](https://github.com/GMLC-TDC/HELICS-src/wiki) with some additional information, and [USER GUIDE]() to help you get started.
+We have an active [Gitter]((https://gitter.im/GMLC-TDC/HELICS) channel
+Our GitHub pages provides a rich set of [documentation](https://helics.readthedocs.io/en/latest/) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen-auto-produced [API documentation](https://helics.readthedocs.io/en/latest/doxygen/index.html), There is a [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) with some additional information, and [USER GUIDE]() to help you get started.
 
 We've created a series of roughly 10-minute mini-tutorial videos that discuss various design topics, concepts, and interfaces, including how to use the tool. They can be found on our [YouTube channel](https://www.youtube.com/channel/UCPa81c4BVXEYXt2EShTzbcg).   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ contributions must be made under this [LICENSE](LICENSE) in accordance with the 
 
 ##  [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 
-If you just have a question about HELICS check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+If you just have a question about HELICS check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
 
-and there are a few questions answered on the github [WIKI](https://github.com/GMLC-TDC/HELICS-src/wiki) page for HELICS.
+and there are a few questions answered on the github [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) page for HELICS.
 
 ## How Can I Contribute?
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,7 +22,7 @@ If you would like to contribute to the HELICS project see [CONTRIBUTING](CONTRIB
 ### [BOOST](https://www.boost.org)
   Boost is used throughout the code, The FMI library makes heavy use of boost::DLL and boost::filesystem for loading and interacting with the FMUs
 
-### [helics](https://github.com/GMLC-TDC/HELICS-src)
+### [helics](https://github.com/GMLC-TDC/HELICS)
   The library is based on HELICS and interacts with the libary
 
 ### [jsoncpp](https://github.com/open-source-parsers/jsoncpp)

--- a/config/cmake/buildHELICS.cmake
+++ b/config/cmake/buildHELICS.cmake
@@ -23,7 +23,7 @@ function (build_helics)
     include(ExternalProject)
 ExternalProject_Add(helics
     SOURCE_DIR ${binary_dir_string}/Download/helics
-    GIT_REPOSITORY  https://github.com/GMLC-TDC/HELICS-src.git
+    GIT_REPOSITORY  https://github.com/GMLC-TDC/HELICS.git
     DOWNLOAD_COMMAND " " 
     UPDATE_COMMAND " " 
     BINARY_DIR ${binary_dir_string}/ThirdParty/helics


### PR DESCRIPTION
Update for the HELICS-src to HELICS repository rename on June 19, 2019.
